### PR TITLE
Added/improved support for some build settings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,8 +23,8 @@ GEM
       thor (~> 0.14.6)
     guard-rspec (0.5.0)
       guard (>= 0.8.4)
-    highline (1.6.2)
-    json (1.6.3)
+    highline (1.6.11)
+    json (1.6.5)
     linecache (0.46)
       rbx-require-relative (> 0.0.4)
     linecache19 (0.5.12)
@@ -34,7 +34,7 @@ GEM
     rbx-require-relative (0.0.5)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    ripl (0.5.1)
+    ripl (0.6.1)
       bond (~> 0.4.0)
     rspec (2.6.0)
       rspec-core (~> 2.6.0)
@@ -59,7 +59,7 @@ GEM
       ruby-debug-base19 (>= 0.11.19)
     ruby_core_source (0.1.5)
       archive-tar-minitar (>= 0.5.2)
-    rubyzip (0.9.4)
+    rubyzip (0.9.5)
     thor (0.14.6)
 
 PLATFORMS

--- a/lib/vendor/spec.rb
+++ b/lib/vendor/spec.rb
@@ -10,7 +10,9 @@ module Vendor
     attr_reader :build_settings
 
     BUILD_SETTING_NAMES = {
-      :other_linker_flags => "OTHER_LDFLAGS"
+      :other_linker_flags => "OTHER_LDFLAGS",
+      :always_search_user_paths => "ALWAYS_SEARCH_USER_PATHS",
+      :user_header_search_paths => "USER_HEADER_SEARCH_PATHS"
     }
 
     ATTRIBUTES.each do |attr|

--- a/spec/lib/vendor/xcode/project_spec.rb
+++ b/spec/lib/vendor/xcode/project_spec.rb
@@ -301,18 +301,66 @@ describe Vendor::XCode::Project do
     it "should create an array of options if the setting is known to be a selection" do
       @temp_project.add_build_setting "OTHER_LDFLAGS", "-ObjC", :targets => "Specs", :changer => "SomeLib"
       @temp_project.add_build_setting "OTHER_LDFLAGS", "-Something", :targets => "Specs", :changer => "SomeLib"
+      @temp_project.add_build_setting "OTHER_LDFLAGS", ["-SomethingElse"], :targets => "Specs", :changer => "SomeLib"
+      @temp_project.add_build_setting "OTHER_LDFLAGS", ["-one", "-two"], :targets => "Specs", :changer => "SomeLib"
 
       @target.build_configuration_list.build_configurations.each do |config|
-        config.build_settings["OTHER_LDFLAGS"].should == [ "-ObjC", "-Something" ]
+        config.build_settings["OTHER_LDFLAGS"].should == [ "-ObjC", "-Something", "-SomethingElse", "-one", "-two" ]
       end
     end
 
-    it "should not duplicate build settings" do
+    it "should not duplicate entries in selection build settings" do
       @temp_project.add_build_setting "OTHER_LDFLAGS", "-ObjC", :targets => "Specs", :changer => "SomeLib"
-      @temp_project.add_build_setting "OTHER_LDFLAGS", "-ObjC", :targets => "Specs", :changer => "SomeLib"
+      @temp_project.add_build_setting "OTHER_LDFLAGS", ["-ObjC", "-Something"], :targets => "Specs", :changer => "SomeLib"
 
       @target.build_configuration_list.build_configurations.each do |config|
-        config.build_settings["OTHER_LDFLAGS"].should == "-ObjC"
+        config.build_settings["OTHER_LDFLAGS"].should == ["-ObjC", "-Something"]
+      end
+    end
+
+    it "should ignore leading/trailing spaces in selection settings" do
+        @temp_project.add_build_setting "OTHER_LDFLAGS", "  -ObjC", :targets => "Specs", :changer => "SomeLib"
+        @temp_project.add_build_setting "OTHER_LDFLAGS", [" -ObjC  ", " -Something  "], :targets => "Specs", :changer => "SomeLib"
+
+        @target.build_configuration_list.build_configurations.each do |config|
+          config.build_settings["OTHER_LDFLAGS"].should == ["-ObjC", "-Something"]
+        end
+      end
+    
+    it "should add a path string" do
+      @temp_project.add_build_setting "USER_HEADER_SEARCH_PATHS", "/dev/null", :targets => "Specs", :changer => "SomeLib"
+      
+      @target.build_configuration_list.build_configurations.each do |config|
+        config.build_settings["USER_HEADER_SEARCH_PATHS"].should == "/dev/null"
+      end
+    end
+
+    it "should add multiple path strings" do
+      @temp_project.add_build_setting "USER_HEADER_SEARCH_PATHS", "/dev/null", :targets => "Specs", :changer => "SomeLib"
+      @temp_project.add_build_setting "USER_HEADER_SEARCH_PATHS", "/user/home", :targets => "Specs", :changer => "SomeLib"
+      
+      @target.build_configuration_list.build_configurations.each do |config|
+        config.build_settings["USER_HEADER_SEARCH_PATHS"].should == "/dev/null /user/home"
+      end
+    end
+
+    it "should not add duplicate path strings" do
+      @temp_project.add_build_setting "USER_HEADER_SEARCH_PATHS", "/dev/null", :targets => "Specs", :changer => "SomeLib"
+      @temp_project.add_build_setting "USER_HEADER_SEARCH_PATHS", "/user/home", :targets => "Specs", :changer => "SomeLib"
+      @temp_project.add_build_setting "USER_HEADER_SEARCH_PATHS", ["/user/home", "/dev/null"], :targets => "Specs", :changer => "SomeLib"
+
+      @target.build_configuration_list.build_configurations.each do |config|
+        config.build_settings["USER_HEADER_SEARCH_PATHS"].should == "/dev/null /user/home"
+      end
+    end
+
+    it "should ignore leading/trailing spaces in path strings" do
+      @temp_project.add_build_setting "USER_HEADER_SEARCH_PATHS", " /dev/null  ", :targets => "Specs", :changer => "SomeLib"
+      @temp_project.add_build_setting "USER_HEADER_SEARCH_PATHS", "   /user/home", :targets => "Specs", :changer => "SomeLib"
+      @temp_project.add_build_setting "USER_HEADER_SEARCH_PATHS", "   /dev/null", :targets => "Specs", :changer => "SomeLib"
+
+      @target.build_configuration_list.build_configurations.each do |config|
+        config.build_settings["USER_HEADER_SEARCH_PATHS"].should == "/dev/null /user/home"
       end
     end
 


### PR DESCRIPTION
Array type build setting values won't overwrite existing settings anymore. The same works for user header search paths which are also joined with existing settings.

```
s.build_setting  :other_linker_flags, [ "-ObjC", "-all_load" ]
s.build_setting  :user_header_search_paths, ["/my/path", "/dev/null"]
```

Especially the user header search path settings will be needed if a full Xcode project is to be imported as dependency.
